### PR TITLE
Split some more of github apart, structs for clients, attach methods to structs, stop passing around copies of things by value, etc...

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -23,15 +23,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v42/github"
 	"github.com/labstack/echo/v4"
 	"github.com/sonatype-nexus-community/the-cla/db"
 	"github.com/sonatype-nexus-community/the-cla/types"
 	webhook "gopkg.in/go-playground/webhooks.v5/github"
 )
-
-const filenameTheClaPem string = "the-cla.pem"
 
 // RepositoriesService handles communication with the repository related methods
 // of the GitHub API.
@@ -70,65 +67,113 @@ type IssuesService interface {
 	ListComments(ctx context.Context, owner string, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 }
 
+type AppsService interface {
+	GetInstallation(ctx context.Context, id int64) (*github.Installation, *github.Response, error)
+}
+
 // GitHubClient manages communication with the GitHub API.
 // https://github.com/google/go-github/issues/113
 type GitHubClient struct {
-	Repositories RepositoriesService
-	Users        UsersService
-	PullRequests PullRequestsService
-	Issues       IssuesService
+	repositories RepositoriesService
+	users        UsersService
+	pullRequests PullRequestsService
+	issues       IssuesService
+	claVersion   string
+	appID        int
+	installID    int
+	db           db.IClaDB
+	logger       echo.Logger
+	botName      string
 }
 
-// GitHubInterface defines all necessary methods.
-// https://godoc.org/github.com/google/go-github/github#NewClient
-type GitHubInterface interface {
-	NewClient(httpClient *http.Client) GitHubClient
+type GitHubClientOptions struct {
+	CLAVersion string
+	AppID      int
+	InstallID  int
+	BotName    string
+}
+
+type IGitHubClient interface {
+	HandlePullRequest(payload webhook.PullRequestPayload) (string, error)
+}
+
+type OAuthGitHubClient struct {
+	users  UsersService
+	logger echo.Logger
+}
+
+type IGitHubJWTClient interface {
+	GetInstallInfo() (*github.Installation, error)
+}
+
+type GitHubJWTClient struct {
+	installID int
+	apps      AppsService
+	logger    echo.Logger
+}
+
+func NewJWTClient(httpClient *http.Client, logger echo.Logger, installID int) IGitHubJWTClient {
+	client := github.NewClient(httpClient)
+	return &GitHubJWTClient{logger: logger, apps: client.Apps, installID: installID}
+}
+
+func (ghj *GitHubJWTClient) GetInstallInfo() (*github.Installation, error) {
+	install, _, err := ghj.apps.GetInstallation(context.Background(), int64(ghj.installID))
+	if err != nil {
+		return nil, err
+	}
+	return install, nil
+}
+
+type IOAuthGitHubClient interface {
+	GetUsers(context context.Context, s string) (*github.User, *github.Response, error)
+}
+
+func NewOAuthClient(httpClient *http.Client, logger echo.Logger) IOAuthGitHubClient {
+	client := github.NewClient(httpClient)
+	return &OAuthGitHubClient{logger: logger, users: client.Users}
+}
+
+func (oa *OAuthGitHubClient) GetUsers(context context.Context, info string) (*github.User, *github.Response, error) {
+	return oa.users.Get(context, info)
 }
 
 // GitHubCreator implements GitHubInterface.
 type GitHubCreator struct{}
 
 // NewClient returns a new GitHubInterface instance.
-func (g *GitHubCreator) NewClient(httpClient *http.Client) GitHubClient {
+func NewClient(httpClient *http.Client, logger echo.Logger, db db.IClaDB, options GitHubClientOptions) IGitHubClient {
 	client := github.NewClient(httpClient)
-	return GitHubClient{
-		Repositories: client.Repositories,
-		Users:        client.Users,
-		PullRequests: client.PullRequests,
-		Issues:       client.Issues,
+	return &GitHubClient{
+		repositories: client.Repositories,
+		users:        client.Users,
+		pullRequests: client.PullRequests,
+		issues:       client.Issues,
+		logger:       logger,
+		db:           db,
+		appID:        options.AppID,
+		claVersion:   options.CLAVersion,
+		botName:      options.BotName,
+		installID:    options.InstallID,
 	}
 }
 
-var githubImpl GitHubInterface = &GitHubCreator{}
-
-func HandlePullRequest(logger echo.Logger,
-	postgres db.IClaDB,
-	payload webhook.PullRequestPayload,
-	appId int,
-	claVersion string) (string, error) {
-	logger.Debug("Attempting to start authenticating with GitHub")
+func (gh *GitHubClient) HandlePullRequest(payload webhook.PullRequestPayload) (string, error) {
+	gh.logger.Debug("Attempting to start authenticating with GitHub")
 
 	owner := payload.Repository.Owner.Login
 	repo := payload.Repository.Name
 	sha := payload.PullRequest.Head.Sha
 	pullRequestID := int(payload.Number)
 
-	logger.Debugf("Transport setup, using appID: %d and installation ID: %d", appId, payload.Installation.ID)
-	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, int64(appId), payload.Installation.ID, filenameTheClaPem)
-	if err != nil {
-		return "", err
-	}
-
-	client := githubImpl.NewClient(&http.Client{Transport: itr})
-
-	err = createRepoStatus(logger, client.Repositories, owner, repo, sha, "pending", "Paul Botsco, the CLA verifier is running")
+	err := gh.createRepoStatus(owner, repo, sha, "pending", "Paul Botsco, the CLA verifier is running")
 	if err != nil {
 		return "", err
 	}
 
 	opts := &github.ListOptions{}
 
-	commits, _, err := client.PullRequests.ListCommits(
+	commits, _, err := gh.pullRequests.ListCommits(
 		context.Background(),
 		owner,
 		repo,
@@ -147,7 +192,7 @@ func HandlePullRequest(logger echo.Logger,
 		// the canonical author of the commit
 		author := *v.GetAuthor()
 
-		hasAuthorSigned, err := postgres.HasAuthorSignedTheCla(*author.Login, claVersion)
+		hasAuthorSigned, err := gh.db.HasAuthorSignedTheCla(*author.Login, gh.claVersion)
 		if err != nil {
 			return "", err
 		}
@@ -159,14 +204,14 @@ func HandlePullRequest(logger echo.Logger,
 						Email:     author.GetEmail(),
 						GivenName: author.GetName(),
 					},
-					CLAVersion: claVersion,
+					CLAVersion: gh.claVersion,
 					//TimeSigned: time.Time{},
 				})
 		}
 	}
 
 	if len(usersNeedingToSignCLA) > 0 {
-		err := createRepoLabel(logger, client.Issues, owner, repo, labelNameCLANotSigned, "ff3333", "The CLA needs to be signed", pullRequestID)
+		err := gh.createRepoLabel(owner, repo, labelNameCLANotSigned, "ff3333", "The CLA needs to be signed", pullRequestID)
 		if err != nil {
 			return "", err
 		}
@@ -179,23 +224,23 @@ func HandlePullRequest(logger echo.Logger,
 		message := "Thanks for the contribution. Before we can merge this, we need %s to sign the Contributor License Agreement"
 		userMsg := strings.Join(users, ",")
 
-		_, err = addCommentToIssueIfNotExists(logger, client.Issues, owner, repo, pullRequestID, fmt.Sprintf(message, userMsg))
+		_, err = gh.addCommentToIssueIfNotExists(owner, repo, pullRequestID, fmt.Sprintf(message, userMsg))
 		if err != nil {
 			return "", err
 		}
 
-		err = createRepoStatus(logger, client.Repositories, owner, repo, sha, "failure", "One or more contributors need to sign the CLA")
+		err = gh.createRepoStatus(owner, repo, sha, "failure", "One or more contributors need to sign the CLA")
 		if err != nil {
 			return "", err
 		}
 	} else {
-		logger.Debug("Attempting to create label for signed CLA")
-		err = createRepoLabel(logger, client.Issues, owner, repo, labelNameCLASigned, "66CC00", "The CLA is signed", pullRequestID)
+		gh.logger.Debug("Attempting to create label for signed CLA")
+		err = gh.createRepoLabel(owner, repo, labelNameCLASigned, "66CC00", "The CLA is signed", pullRequestID)
 		if err != nil {
 			return "", err
 		}
 
-		err = createRepoStatus(logger, client.Repositories, owner, repo, sha, "success", "All contributors have signed the CLA")
+		err = gh.createRepoStatus(owner, repo, sha, "success", "All contributors have signed the CLA")
 		if err != nil {
 			return "", err
 		}
@@ -204,10 +249,9 @@ func HandlePullRequest(logger echo.Logger,
 	return "things", nil
 }
 
-func createRepoStatus(logger echo.Logger,
-	repositoryService RepositoriesService,
+func (gh *GitHubClient) createRepoStatus(
 	owner, repo, sha, state, description string) error {
-	_, _, err := repositoryService.CreateStatus(context.Background(), owner, repo, sha, &github.RepoStatus{State: &state, Description: &description})
+	_, _, err := gh.repositories.CreateStatus(context.Background(), owner, repo, sha, &github.RepoStatus{State: &state, Description: &description, Context: &gh.botName})
 	if err != nil {
 		return err
 	}
@@ -217,18 +261,16 @@ func createRepoStatus(logger echo.Logger,
 const labelNameCLANotSigned string = ":monocle_face: cla not signed"
 const labelNameCLASigned string = ":heart_eyes: cla signed"
 
-func createRepoLabel(logger echo.Logger,
-	issuesService IssuesService,
-	owner, repo, name, color, description string,
+func (gh *GitHubClient) createRepoLabel(owner, repo, name, color, description string,
 	pullRequestID int) error {
-	logger.Debugf("Attempting to add or create label for: %s", name)
+	gh.logger.Debugf("Attempting to add or create label for: %s", name)
 
-	lbl, err := _createRepoLabelIfNotExists(logger, issuesService, owner, repo, name, color, description)
+	lbl, err := gh._createRepoLabelIfNotExists(owner, repo, name, color, description)
 	if err != nil {
 		return err
 	}
 
-	_, err = _addLabelToIssueIfNotExists(logger, issuesService, owner, repo, pullRequestID, lbl.GetName())
+	_, err = gh._addLabelToIssueIfNotExists(owner, repo, pullRequestID, lbl.GetName())
 	if err != nil {
 		return err
 	}
@@ -236,25 +278,24 @@ func createRepoLabel(logger echo.Logger,
 	return nil
 }
 
-func _createRepoLabelIfNotExists(logger echo.Logger,
-	issuesService IssuesService,
+func (gh *GitHubClient) _createRepoLabelIfNotExists(
 	owner, repo, name, color, description string) (desiredLabel *github.Label, err error) {
-	logger.Debugf("Attempting to create label: %s", name)
+	gh.logger.Debugf("Attempting to create label: %s", name)
 
-	desiredLabel, res, err := issuesService.GetLabel(context.Background(), owner, repo, name)
+	desiredLabel, res, err := gh.issues.GetLabel(context.Background(), owner, repo, name)
 	if res.StatusCode == 404 {
-		logger.Debugf("Looks like the label doesn't exist, so create it, name: %s, color: %s, description: %s", name, color, description)
+		gh.logger.Debugf("Looks like the label doesn't exist, so create it, name: %s, color: %s, description: %s", name, color, description)
 
 		strName := name
 		strColor := color
 		strDescription := description
 		newLabel := &github.Label{Name: &strName, Color: &strColor, Description: &strDescription}
-		desiredLabel, _, err = issuesService.CreateLabel(context.Background(), owner, repo, newLabel)
+		desiredLabel, _, err = gh.issues.CreateLabel(context.Background(), owner, repo, newLabel)
 
 		return
 	}
 	if desiredLabel != nil {
-		logger.Debugf("Found existing label, returning it %+v", desiredLabel)
+		gh.logger.Debugf("Found existing label, returning it %+v", desiredLabel)
 
 		return
 	}
@@ -262,9 +303,9 @@ func _createRepoLabelIfNotExists(logger echo.Logger,
 	return
 }
 
-func addCommentToIssueIfNotExists(logger echo.Logger, issuesService IssuesService, owner, repo string, issueNumber int, message string) (*github.IssueComment, error) {
+func (gh *GitHubClient) addCommentToIssueIfNotExists(owner, repo string, issueNumber int, message string) (*github.IssueComment, error) {
 	opts := &github.IssueListCommentsOptions{}
-	comments, _, err := issuesService.ListComments(context.Background(), owner, repo, issueNumber, opts)
+	comments, _, err := gh.issues.ListComments(context.Background(), owner, repo, issueNumber, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +320,7 @@ func addCommentToIssueIfNotExists(logger echo.Logger, issuesService IssuesServic
 		prComment := &github.IssueComment{}
 		prComment.Body = &message
 
-		comment, _, err := issuesService.CreateComment(context.Background(), owner, repo, issueNumber, prComment)
+		comment, _, err := gh.issues.CreateComment(context.Background(), owner, repo, issueNumber, prComment)
 		if err != nil {
 			return nil, err
 		}
@@ -289,16 +330,16 @@ func addCommentToIssueIfNotExists(logger echo.Logger, issuesService IssuesServic
 	return nil, nil
 }
 
-func _addLabelToIssueIfNotExists(logger echo.Logger, issuesService IssuesService, owner, repo string, issueNumber int, labelName string) (desiredLabel *github.Label, err error) {
+func (gh *GitHubClient) _addLabelToIssueIfNotExists(owner, repo string, issueNumber int, labelName string) (desiredLabel *github.Label, err error) {
 	// check if label is already added to issue
 	opts := github.ListOptions{}
-	issueLabels, _, err := issuesService.ListLabelsByIssue(context.Background(), owner, repo, issueNumber, &opts)
+	issueLabels, _, err := gh.issues.ListLabelsByIssue(context.Background(), owner, repo, issueNumber, &opts)
 	if err != nil {
 		return
 	}
 	for _, existingLabel := range issueLabels {
 		if *existingLabel.Name == labelName {
-			logger.Debug("Found label on issue, getting out of here")
+			gh.logger.Debug("Found label on issue, getting out of here")
 			// label already exists on this issue
 			desiredLabel = existingLabel
 			return
@@ -307,9 +348,9 @@ func _addLabelToIssueIfNotExists(logger echo.Logger, issuesService IssuesService
 
 	// didn't find the label on this issue, so add the label to this issue
 	// @TODO Verify this does not remove existing labels (any label not in our "add" array)
-	logger.Debug("Attempting to add label to issue")
-	logger.Debugf("Label: %s", labelName)
-	_, _, err = issuesService.AddLabelsToIssue(
+	gh.logger.Debug("Attempting to add label to issue")
+	gh.logger.Debugf("Label: %s", labelName)
+	_, _, err = gh.issues.AddLabelsToIssue(
 		context.Background(),
 		owner,
 		repo,

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -28,8 +28,6 @@ import (
 	githuboauth "golang.org/x/oauth2/github"
 )
 
-var githubImpl ourGithub.GitHubInterface = &ourGithub.GitHubCreator{}
-
 type OAuthInterface interface {
 	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	Client(ctx context.Context, t *oauth2.Token) *http.Client
@@ -62,9 +60,9 @@ func (oa *OAuthImpl) GetOAuthUser(logger echo.Logger, code string) (user *github
 
 	oauthClient := oa.Client(context.Background(), token)
 
-	client := githubImpl.NewClient(oauthClient)
+	client := ourGithub.NewOAuthClient(oauthClient, logger)
 
-	user, _, err = client.Users.Get(context.Background(), "")
+	user, _, err = client.GetUsers(context.Background(), "")
 	if err != nil {
 		logger.Error(err)
 		return
@@ -88,5 +86,3 @@ func CreateOAuth(clientID, clientSecret string) OAuthInterface {
 	}
 	return &oAuthImpl
 }
-
-var oauthImpl OAuthInterface

--- a/server.go
+++ b/server.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+//go:build go1.16
 // +build go1.16
 
 package main
@@ -160,6 +161,14 @@ func handleProcessWebhook(c echo.Context) (err error) {
 				c.Logger().Error(err)
 				return c.String(http.StatusBadRequest, err.Error())
 			}
+
+			app, err := ghJWTClient.Get()
+			if err != nil {
+				c.Logger().Error(err)
+				return c.String(http.StatusBadRequest, err.Error())
+			}
+			c.Logger().Debugf("app name: %s", *app.Name)                // for display in status messages on GH
+			c.Logger().Debugf("app external url: %s", *app.ExternalURL) // the link for the user to sign the CLA
 
 			// See if we can move this to a longer lived thing, maybe? It's going to recreate the transport and http Client each time we get a payload
 			c.Logger().Debugf("Transport setup, using appID: %d and installation ID: %d", appId, payload.Installation.ID)


### PR DESCRIPTION
I mostly focused on our `github` package, and did a few things, adding some interfaces, helper methods for obtaining things, and trying to stuff things in the right areas so we are constantly passing around loggers, etc...

I THINK this looks cleaner, and it feels cleaner.

Beyond that, I implemented one new API (I think) around checking the GH API (via JWT auth, which is new too) about our apps install, so I can get the botname, etc....