### PR TITLE
Link to Sign CLA page. Adapted from PR #56. Happy to change as needed.

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -242,14 +242,15 @@ func HandlePullRequest(logger *zap.Logger, postgres db.IClaDB, payload webhook.P
 }
 
 func getApp(logger *zap.Logger, appId int) (app *github.App, err error) {
-	// Getting a JWT Apps Transport to ask GitHub about stuff that needs a JWT for asking, such as installInfo
-	atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, int64(appId), FilenameTheClaPem)
+	// Getting a JWT Apps Transport to ask GitHub about stuff that needs a JWT for asking, such as App
+	var atr *ghinstallation.AppsTransport
+	atr, err = ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, int64(appId), FilenameTheClaPem)
 	if err != nil {
 		logger.Error("failed to get JWT",
 			zap.Int("appId", appId),
 			zap.Error(err),
 		)
-		return nil, err
+		return
 	}
 	jwtClient := GHImpl.NewClient(&http.Client{Transport: atr})
 	app, _, err = jwtClient.Apps.Get(context.Background(),
@@ -260,9 +261,9 @@ func getApp(logger *zap.Logger, appId int) (app *github.App, err error) {
 			zap.Int("appId", appId),
 			zap.Error(err),
 		)
-		return nil, err
+		return
 	}
-	return app, nil
+	return
 }
 
 func createRepoStatus(repositoryService RepositoriesService, owner, repo, sha, state, description string) error {

--- a/github/github.go
+++ b/github/github.go
@@ -73,6 +73,16 @@ type IssuesService interface {
 	ListComments(ctx context.Context, owner string, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 }
 
+// AppsService provides access to the installation related functions
+// in the GitHub API.
+//
+// GitHub API docs: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps/
+type AppsService interface {
+	// Get a single GitHub App. Passing the empty string will get
+	// the authenticated GitHub App.
+	Get(ctx context.Context, appSlug string) (*github.App, *github.Response, error)
+}
+
 // GHClient manages communication with the GitHub API.
 // https://github.com/google/go-github/issues/113
 type GHClient struct {
@@ -80,6 +90,7 @@ type GHClient struct {
 	Users        UsersService
 	PullRequests PullRequestsService
 	Issues       IssuesService
+	Apps         AppsService
 }
 
 // GHInterface defines all necessary methods.
@@ -99,6 +110,7 @@ func (g *GHCreator) NewClient(httpClient *http.Client) GHClient {
 		Users:        client.Users,
 		PullRequests: client.PullRequests,
 		Issues:       client.Issues,
+		Apps:         client.Apps,
 	}
 }
 
@@ -187,10 +199,36 @@ func HandlePullRequest(logger *zap.Logger, postgres db.IClaDB, payload webhook.P
 			users = append(users, " @"+v.User.Login)
 		}
 
-		message := "Thanks for the contribution. Before we can merge this, we need %s to sign the Contributor License Agreement"
+		// get info needed to show link to sign the cla
+
+		// Getting a JWT Apps Transport to ask GitHub about stuff that needs a JWT for asking, such as installInfo
+		atr, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, int64(appId), FilenameTheClaPem)
+		if err != nil {
+			logger.Error("failed to get JWT",
+				zap.Int("appId", appId),
+				zap.Error(err),
+			)
+			return err
+		}
+		jwtClient := GHImpl.NewClient(&http.Client{Transport: atr})
+		app, _, err := jwtClient.Apps.Get(context.Background(),
+			// Passing the empty string will get the authenticated GitHub App.
+			"")
+		if err != nil {
+			logger.Error("failed to get app",
+				zap.Int("appId", appId),
+				zap.Error(err),
+			)
+			return err
+		}
+		// TODO Maybe use app.Name in the remaining hard coded Paul Botsco repo status message above...or not.
+		//appName := app.Name
+		appExternalUrl := *app.ExternalURL
+
+		message := "Thanks for the contribution. Before we can merge this, we need %s to [sign the Contributor License Agreement](%s)"
 		userMsg := strings.Join(users, ",")
 
-		_, err = addCommentToIssueIfNotExists(client.Issues, owner, repo, pullRequestID, fmt.Sprintf(message, userMsg))
+		_, err = addCommentToIssueIfNotExists(client.Issues, owner, repo, pullRequestID, fmt.Sprintf(message, userMsg, appExternalUrl))
 		if err != nil {
 			return err
 		}

--- a/github/github.go
+++ b/github/github.go
@@ -200,11 +200,11 @@ func HandlePullRequest(logger *zap.Logger, postgres db.IClaDB, payload webhook.P
 		}
 
 		// get info needed to show link to sign the cla
-		app, err2 := getApp(logger, appId)
-		if err2 != nil {
-			return err2
+		app, err := getApp(logger, appId)
+		if err != nil {
+			return err
 		}
-		// TODO Maybe use app.Name in the remaining hard coded Paul Botsco repo status message above...or not.
+		// Maybe use app.Name in the remaining hard coded Paul Botsco repo status message above...or not.
 		//appName := app.Name
 		appExternalUrl := *app.ExternalURL
 
@@ -246,7 +246,7 @@ func getApp(logger *zap.Logger, appId int) (app *github.App, err error) {
 	var atr *ghinstallation.AppsTransport
 	atr, err = ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, int64(appId), FilenameTheClaPem)
 	if err != nil {
-		logger.Error("failed to get JWT",
+		logger.Error("failed to get JWT key",
 			zap.Int("appId", appId),
 			zap.Error(err),
 		)

--- a/github/github_mocks.go
+++ b/github/github_mocks.go
@@ -168,12 +168,26 @@ func (i *IssuesMock) ListComments(ctx context.Context, owner string, repo string
 	return i.mockListComments, i.mockListCommentsResponse, i.mockListCommentsError
 }
 
+type AppsMock struct {
+	mockApp     *github.App
+	mockAppResp *github.Response
+	mockAppErr  error
+}
+
+var _ AppsService = (*AppsMock)(nil)
+
+//goland:noinspection GoUnusedParameter
+func (a *AppsMock) Get(ctx context.Context, appSlug string) (*github.App, *github.Response, error) {
+	return a.mockApp, a.mockAppResp, a.mockAppErr
+}
+
 // GHInterfaceMock implements GHInterface.
 type GHInterfaceMock struct {
 	RepositoriesMock RepositoriesMock
 	UsersMock        UsersMock
 	PullRequestsMock PullRequestsMock
 	IssuesMock       IssuesMock
+	AppsMock         AppsMock
 }
 
 var _ GHInterface = (*GHInterfaceMock)(nil)
@@ -208,6 +222,11 @@ func (g *GHInterfaceMock) NewClient(httpClient *http.Client) GHClient {
 			mockAddLabelsError:            g.IssuesMock.mockAddLabelsError,
 			MockRemoveLabelResponse:       g.IssuesMock.MockRemoveLabelResponse,
 			mockRemoveLabelError:          g.IssuesMock.mockRemoveLabelError,
+		},
+		Apps: &AppsMock{
+			mockApp:     g.AppsMock.mockApp,
+			mockAppResp: g.AppsMock.mockAppResp,
+			mockAppErr:  g.AppsMock.mockAppErr,
 		},
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-cla",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "private": true,
   "dependencies": {
     "@sonatype/react-shared-components": "^9.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-cla",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "dependencies": {
     "@sonatype/react-shared-components": "^9.5.16",

--- a/server.go
+++ b/server.go
@@ -195,6 +195,7 @@ func handleSignature(c echo.Context) (err error) {
 	// hide sensitive info
 	foundUserSignature.User.Email = hiddenFieldValue
 	foundUserSignature.User.GivenName = hiddenFieldValue
+	logger.Debug("found login signature", zap.Any("foundUserSignature", foundUserSignature))
 	return c.JSON(http.StatusOK, foundUserSignature)
 }
 


### PR DESCRIPTION
This PR uses the neato JWT stuff from PR #56, but doesn't move stuff around as much.

We can move stuff around from this PR if desired, but it was proving very tricky to do it all (merge to 'main') in PR #56.

This PR adds a link to allow the user to sign the CLA if needed (and only queries the GH API for that info when needed - when not needed, the JWT stuff is not invoked). The sign link is added to the comment we add if signatures are missing.

Fixes #59