### PR TITLE
feat: make location of `the-cla.pem` configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ GH_WEBHOOK_SECRET=totallysecret
 GH_APP_ID=1337
 INFO_USERNAME=theInfoUsername
 INFO_PASSWORD=theInfoPassword
+CLA_PEM_FILE=/path/to/the-cla.pem
 ```
 
 The important things to update are:
@@ -181,6 +182,7 @@ The important things to update are:
 - `SSL_MODE=disable` - this only exists to enable local development with a local database. Remove this setting for deployment to AWS.
 - `INFO_USERNAME` - the username to access the "info" endpoint, e.g. to check if a particular login has signed the cla.
 - `INFO_PASSWORD` - the password to access the "info" endpoint, e.g. to check if a particular login has signed the cla.
+- `CLA_PEM_FILE` - Path to `the-cla.pem` (optional - defaults to just `the-cla.pem` if not defined)
 
 Since these are all environment variables, you can just set them that way if you prefer, but it's important these variables are available at build time, as we inject these into the React code, which is honestly pretty sweet!
 

--- a/github/github.go
+++ b/github/github.go
@@ -22,12 +22,13 @@ package github
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v42/github"
@@ -36,7 +37,16 @@ import (
 	webhook "gopkg.in/go-playground/webhooks.v5/github"
 )
 
-const FilenameTheClaPem string = "the-cla.pem"
+func getpemlocation() string {
+	fromenv := os.Getenv("CLA_PEM_FILE")
+	if len(fromenv) == 0 {
+		return "the-cla.pem"
+	}
+	return fromenv
+}
+
+var FilenameTheClaPem string = getpemlocation()
+
 const EnvGhAppId = "GH_APP_ID"
 
 // RepositoriesService handles communication with the repository related methods

--- a/main.tf
+++ b/main.tf
@@ -75,9 +75,14 @@ resource "kubernetes_deployment" "the_cla" {
 
       spec {
         container {
-          image             = "sonatypecommunity/the-cla:latest"
+          image             = "sonatypecommunity/the-cla:v0.0.3"
           name              = "the-cla"
           image_pull_policy = "IfNotPresent"
+
+          env {
+            name = "CLA_PEM_FILE"
+            value = "/the-cla-secrets/the-cla.pem"
+          }
 
           env {
             name = "GITHUB_CLIENT_SECRET"


### PR DESCRIPTION
As we can't mount it at `/` in Kubernetes it seems 😢 