### PR TITLE
fix: hide test email endpoint on the authenticated `/info` subpath

### DIFF
--- a/server.go
+++ b/server.go
@@ -169,8 +169,7 @@ func main() {
 
 	g := e.Group(pathInfo, middleware.BasicAuth(infoBasicValidator))
 	g.GET(pathSignature, handleSignature)
-
-	e.GET(pathTestEmail, handleTestEmail)
+	g.GET(pathTestEmail, handleTestEmail)
 
 	e.Static("/", buildLocation)
 


### PR DESCRIPTION
Minor protection before we GTM.