### PR TITLE
fix: Update trigger to be `pull_request_target` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Continuous Integration
 # This GitHub action runs your tests for each pull request and push.
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
-    pull_request:
-        paths-ignore:
-            - 'README.md'
+    pull_request_target:
+        branches:
+            - main
     push:
         branches:
             - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Continuous Integration
 # This GitHub action runs your tests for each pull request and push.
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
+    pull_request:
+        paths-ignore:
+            - 'README.md'
     pull_request_target:
         branches:
             - main


### PR DESCRIPTION
Fixes #101 

So CI runs with the context of the Base of the PR - see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

@eddie-knight - does this meet your expectation?