### PR TITLE
update mocks to assert multiple calls to mock functions

### DIFF
--- a/github/github_mocks.go
+++ b/github/github_mocks.go
@@ -32,7 +32,7 @@ import (
 // RepositoriesMock mocks RepositoriesService
 type RepositoriesMock struct {
 	t *testing.T
-	/* callCount is the number of times the createRepoStatus function has been called by production code. */
+	/* callCount is the number of times the CreateStatus function has been called by production code. */
 	callCount int
 	/* assertParameters is a slice of booleans that determine whether to assert the parameters passed to the function for
 	each call to the CreateStatus function. If the value at the index of the callCount is true, the parameters will be

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -394,18 +394,17 @@ func TestWithFullEnvironment(t *testing.T) {
 		repositoriesMock := *setupMockRepositoriesService(t, []bool{true, true})
 		repositoriesMock.expectedCtx = []context.Context{context.Background(), context.Background()}
 
-		status1 := &github.RepoStatus{
-			State:       github.String("pending"),
-			Description: github.String("Paul Botsco, the CLA verifier is running"),
-			Context:     &MockAppSlug,
-		}
-		status2 := &github.RepoStatus{
-			State:       github.String("failure"),
-			Description: github.String("One or more commits haven't met our Quality requirements."),
-			Context:     &MockAppSlug,
-		}
 		repositoriesMock.expectedCreateStatusRepoStatus = []*github.RepoStatus{
-			status1, status2,
+			{
+				State:       github.String("pending"),
+				Description: github.String("Paul Botsco, the CLA verifier is running"),
+				Context:     &MockAppSlug,
+			},
+			{
+				State:       github.String("failure"),
+				Description: github.String("One or more commits haven't met our Quality requirements."),
+				Context:     &MockAppSlug,
+			},
 		}
 
 		GHImpl = getGHMock(getMockRepositoryCommits(authors, false), nil, &repositoriesMock)

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -20,6 +20,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -351,7 +352,7 @@ func TestWithFullEnvironment(t *testing.T) {
 	t.Run("TestHandlePullRequestListCommitsError", func(t *testing.T) {
 		forcedError := fmt.Errorf("forced ListCommits error")
 		GHImpl = &GHInterfaceMock{
-			RepositoriesMock: *setupMockRepositoriesService(t, false),
+			RepositoriesMock: *setupMockRepositoriesService(t, []bool{false}),
 			PullRequestsMock: PullRequestsMock{
 				mockListCommitsError: forcedError,
 			},
@@ -369,7 +370,7 @@ func TestWithFullEnvironment(t *testing.T) {
 		GHJWTImpl = &GHJWTMock{
 			AppsMock: AppsMock{
 				mockInstallation: &github.Installation{
-					AppSlug: &appSlug,
+					AppSlug: &MockAppSlug,
 				},
 				mockAppResp: &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
 				mockApp:     &github.App{ExternalURL: &mockExternalUrl},
@@ -389,7 +390,25 @@ func TestWithFullEnvironment(t *testing.T) {
 
 	t.Run("TestHandlePullRequestListCommitsUnsignedCommit", func(t *testing.T) {
 		authors := []string{"john", "doe"}
-		GHImpl = getGHMock(getMockRepositoryCommits(authors, false), nil, nil)
+
+		repositoriesMock := *setupMockRepositoriesService(t, []bool{true, true})
+		repositoriesMock.expectedCtx = []context.Context{context.Background(), context.Background()}
+
+		status1 := &github.RepoStatus{
+			State:       github.String("pending"),
+			Description: github.String("Paul Botsco, the CLA verifier is running"),
+			Context:     &MockAppSlug,
+		}
+		status2 := &github.RepoStatus{
+			State:       github.String("failure"),
+			Description: github.String("One or more commits haven't met our Quality requirements."),
+			Context:     &MockAppSlug,
+		}
+		repositoriesMock.expectedCreateStatusRepoStatus = []*github.RepoStatus{
+			status1, status2,
+		}
+
+		GHImpl = getGHMock(getMockRepositoryCommits(authors, false), nil, &repositoriesMock)
 		mockDB, logger := setupMockDB(t, false)
 		err := HandlePullRequest(logger, mockDB, webhook.PullRequestPayload{}, 0, "")
 		assert.NoError(t, err)
@@ -412,7 +431,7 @@ func TestHandlePullRequestGetAppError(t *testing.T) {
 	GHJWTImpl = &GHJWTMock{
 		AppsMock: AppsMock{
 			mockInstallation: &github.Installation{
-				AppSlug: &appSlug,
+				AppSlug: &MockAppSlug,
 			},
 			//mockAppErr: forcedError,
 			mockAppResp: &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
@@ -496,7 +515,7 @@ func TestHandlePullRequestListCommitsNoAuthor(t *testing.T) {
 	GHJWTImpl = &GHJWTMock{
 		AppsMock: AppsMock{
 			mockInstallation: &github.Installation{
-				AppSlug: &appSlug,
+				AppSlug: &MockAppSlug,
 			},
 			mockAppResp: &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
 			mockApp:     &github.App{ExternalURL: &mockExternalUrl},
@@ -630,7 +649,7 @@ func TestReviewPriorPRsEvaluatePRError(t *testing.T) {
 	GHImpl = &GHInterfaceMock{
 		RepositoriesMock: RepositoriesMock{
 			t:                 t,
-			createStatusError: forcedError,
+			createStatusError: []error{forcedError},
 		},
 	}
 


### PR DESCRIPTION
This PR updates our mocks to support multiple calls to mocked functions and validating each call individually. The idea is to allow optional assertions on the mock calls. If you do not find this too disgusting, feel free to merge it into PR #114. 

My intent is to allow the mocks to better assert unit test conditions going forward.

(I'm totally fine with replacing all of this with a better mock library in the future.)